### PR TITLE
fix: add support for IRPF 2025 tax tables with interactive period selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,34 @@ Oi, pessoal! Aqui é onde a mágica acontece no mundo dos cálculos da PLR (Part
 ## 🚀 Funcionalidades
 
 - **Cálculo da PLR**: Basta informar seu salário, multiplicador, porcentagem e meses trabalhados.
+- **Cálculo de IRPF**: Calcula automaticamente o Imposto de Renda sobre a PLR com as tabelas 2025.
+- **Escolha de Período**: Selecione entre as tabelas de Janeiro-Abril/2025 ou Maio+/2025.
 - **Logs Detalhados**: Com Logrus, você fica por dentro de tudo o que acontece durante o cálculo.
 - **Interface Amigável**: Graças ao Cobra, nossa CLI é fácil até para quem nunca viu uma linha de código.
+
+## 🐠 Tabelas IRPF 2025
+
+O calculador utiliza as tabelas oficiais de IRPF para PLR:
+
+### Janeiro a Abril/2025
+
+| Faixa | Alíquota | Dedução |
+|--------|----------|----------|
+| Até R$ 7.640,00 | 0% (isento) | R$ 0,00 |
+| R$ 7.640,01 a R$ 9.922,28 | 7,5% | R$ 573,06 |
+| R$ 9.922,29 a R$ 13.167,00 | 15% | R$ 1.317,23 |
+| R$ 13.167,01 a R$ 16.380,38 | 22,5% | R$ 2.304,76 |
+| Acima de R$ 16.380,38 | 27,5% | R$ 3.123,78 |
+
+### A partir de Maio/2025 ✅ (padrão)
+
+| Faixa | Alíquota | Dedução |
+|--------|----------|----------|
+| Até R$ 8.214,40 | 0% (isento) | R$ 0,00 |
+| R$ 8.214,41 a R$ 9.922,28 | 7,5% | R$ 616,08 |
+| R$ 9.922,29 a R$ 13.167,00 | 15% | R$ 1.360,25 |
+| R$ 13.167,01 a R$ 16.380,38 | 22,5% | R$ 2.347,78 |
+| Acima de R$ 16.380,38 | 27,5% | R$ 3.166,80 |
 
 ## 🛠 Tecnologias Usadas
 
@@ -38,14 +64,13 @@ Você vai precisar do Go (1.24+), Git e uma xícara de café (ou chá, se prefer
    ```
    (E veja o `plr_calculator` ganhar vida!)
 
-
 4. **Teve problemas ou dificuldades no build? Relaxa tenho a solução para você :**
    ```sh
    Acesse o link: https://github.com/diillson/calculador-de-plr/releases
    na ultima Release, terá já buildado pelo workflow,versões para Mac(Darwin), Linux e Windows.
    Basta baixar, extrair e executar em seu terminal Linux e Mac ou Prompt/PowerShell sendo Windows.
-      
-   Obs: no Linux e Mac será necessário permitir a execução do binário, basta passar o comando: chmod +x plr_calculator-OS
+       
+   Obs: no Linux e Mac será necessário permitir a execução do binário, basta passar o comando: chmod +x *
    caso abrir a mensagem de que o binario não pode ser executado por não haver desenvolvedor declarado,
    basta clicar com o botao direito e mandar executar com o seu terminal de preferencia,
    com isso nas proximas execuções poderá chamar o binario direto pelo terminal.
@@ -56,7 +81,7 @@ Você vai precisar do Go (1.24+), Git e uma xícara de café (ou chá, se prefer
 
 Depois de compilar, só rodar:
 
-**🚀 Uso de Flags!**
+### 🚀 Uso de Flags!
 
 Você pode usar as seguintes flags para fornecer dados ao aplicativo:
 
@@ -64,39 +89,53 @@ Você pode usar as seguintes flags para fornecer dados ao aplicativo:
     --multiplicador ou -m: Especifica o multiplicador da PLR.
     --participacao ou -p: Define a porcentagem de participação nos lucros.
     --meses ou -t: Informa o número de meses trabalhados.
+    --periodo: Escolhe a tabela IRPF: jan-abr ou maio-mais (padrão).
 
-## Exemplo de Uso com Flags
+### Exemplo de Uso com Flags
 
-Execute o calculador da PLR com flags assim:
+**Usando tabela Maio+/2025 (padrão):**
 ```sh
-
-./plr_calculator --salario 7000 --multiplicador 2 --participacao 83 --meses 12
-```
-
-Ou de forma mais curta:
-```sh
-
 ./plr_calculator -s 7000 -m 2 -p 83 -t 12
 ```
 
-**Usando --help**
+**Usando tabela Janeiro-Abril/2025:**
+```sh
+./plr_calculator -s 7000 -m 2 -p 83 -t 12 --periodo jan-abr
+```
 
-Quer saber mais sobre as flags? Simples! Use a flag --help para obter uma descrição detalhada de todas as opções disponíveis:
+**Forma curta:**
+```sh
+./plr_calculator --salario 7000 --multiplicador 2 --participacao 83 --meses 12 --periodo maio-mais
+```
+
+### **Usando --help**
+
+Quer saber mais sobre as flags? Simples! Use a flag --help para obter uma descrição detalhada de todas as oqções disponíveis:
 
 ```sh
-
 ./plr_calculator --help
 ```
 
-**Usando de forma interativa**
+### **Usando de forma interativa**
 
 ```sh
 ./plr_calculator
 ```
 
-E seguir o que a tela te diz. Vai ser divertido, prometo!
+E seguir o que a tela te diz. Você poderá escolher o período da tabela IRPF:
 
-## 🤝 Contribuições são Super Bem-vindas
+```
+Digite o salário: 7000
+Digite o multiplicador da PLR: 2
+Digite a porcentagem de participação nos lucros: 83
+Digite o número de meses trabalhados: 12
+Escolha o período da tabela IRPF:
+1) Janeiro a Abril/2025
+2) A partir de Maio/2025 (padrão)
+Digite sua escolha (1 ou 2): 2
+```
+
+## 🤤 Contribuições são Super Bem-vindas
 
 Tem uma ideia brilhante? Encontrou um bugzinho? Contribuições são o coração do open source. Confira as `CONTRIBUTING.md` para saber como fazer parte desta aventura.
 
@@ -104,7 +143,7 @@ Tem uma ideia brilhante? Encontrou um bugzinho? Contribuições são o coração
 
 Este tesouro está sob a licença [MIT](https://github.com/diillson/calculador-de-plr/blob/main/LICENSE). Veja `LICENSE` para detalhes.
 
-## 📚 Aprenda Mais
+## 📺 Aprenda Mais
 
 Quer aprender mais sobre PLR, Go ou como criamos este app? Dá uma olhada nestes recursos:
 

--- a/internal/domain/plr.go
+++ b/internal/domain/plr.go
@@ -23,20 +23,38 @@ type ResultadoIRPF struct {
 	ValorLiquido   float64
 }
 
-// TabelaIRPF retorna a tabela de IRPF atualizada para 2024/2025 (valores anuais)
-func TabelaIRPF() []FaixaIRPF {
+// Tabela de IRPF especifica de PLR (valores anuais).
+
+// De janeiro a abril de 2025
+func TabelaIRPFPLRJanAbr2025() []FaixaIRPF {
 	return []FaixaIRPF{
-		{0.0, 28467.20, 0.0, 0.0},                // Isento
-		{28467.21, 33919.80, 7.5, 2135.04},       // Primeira faixa
-		{33919.81, 45012.60, 15.0, 4679.03},      // Segunda faixa
-		{45012.61, 55976.16, 22.5, 8054.97},      // Terceira faixa
-		{55976.17, 999999999.99, 27.5, 10853.78}, // Quarta faixa
+		{0.0, 7640.80, 0.0, 0.0},
+		{7640.81, 9922.28, 7.5, 573.06},
+		{9922.29, 13167.00, 15.0, 1317.23},
+		{13167.01, 16380.38, 22.5, 2304.76},
+		{16380.39, 999999999.99, 27.5, 3123.78},
 	}
+}
+
+// A partir de maio de 2025
+func TabelaIRPFPLRAPartirDeMaio2025() []FaixaIRPF {
+	return []FaixaIRPF{
+		{0.0, 8214.40, 0.0, 0.0},
+		{8214.41, 9922.28, 7.5, 616.08},
+		{9922.29, 13167.00, 15.0, 1360.25},
+		{13167.01, 16380.38, 22.5, 2347.78},
+		{16380.39, 999999999.99, 27.5, 3166.80},
+	}
+}
+
+// TabelaIRPFPLR retorna por padrao a tabela mais recente (a partir de maio/2025).
+func TabelaIRPFPLR() []FaixaIRPF {
+	return TabelaIRPFPLRAPartirDeMaio2025()
 }
 
 func (p PLRDados) Calcular() (float64, error) {
 	if p.Salario < 0 || p.Multiplicador < 0 || p.PorcentagemParticipacao < 0 || p.MesesTrabalhados < 0 || p.MesesTrabalhados > 12 {
-		return 0, errors.New("valores inválidos para o cálculo da PLR")
+		return 0, errors.New("valores invalidos para o calculo da PLR")
 	}
 
 	plrBruta := p.Salario * p.Multiplicador * p.PorcentagemParticipacao

--- a/internal/finance/calculator.go
+++ b/internal/finance/calculator.go
@@ -18,9 +18,7 @@ func formatarNumero(num float64) string {
 	partes := strings.Split(s, ".")
 	inteiro := partes[0]
 	decimal := partes[1]
-
 	inteiroInvertido := reverseString(inteiro)
-
 	var comVirgulas strings.Builder
 	for i, char := range inteiroInvertido {
 		if i > 0 && i%3 == 0 {
@@ -28,7 +26,6 @@ func formatarNumero(num float64) string {
 		}
 		comVirgulas.WriteRune(char)
 	}
-
 	inteiroFormatado := reverseString(comVirgulas.String())
 	return inteiroFormatado + "." + decimal
 }
@@ -45,7 +42,6 @@ func (c *Calculator) CalcularPLR(dados domain.PLRDados) (string, error) {
 	if dados.PorcentagemParticipacao > 1 {
 		dados.PorcentagemParticipacao /= 100
 	}
-
 	plr, err := dados.Calcular()
 	if err != nil {
 		logrus.WithFields(logrus.Fields{
@@ -56,19 +52,16 @@ func (c *Calculator) CalcularPLR(dados domain.PLRDados) (string, error) {
 		}).Errorf("Erro ao calcular PLR: %v", err)
 		return "", err
 	}
-
 	plrFormatado := formatarNumero(plr)
 	return plrFormatado, nil
 }
 
-// determinarFaixaIRPF determina a faixa de IRPF baseada no valor anual
 func determinarFaixaIRPF(valorAnual float64, tabela []domain.FaixaIRPF) int {
 	for i, faixa := range tabela {
 		if valorAnual >= faixa.LimiteInferior && valorAnual <= faixa.LimiteSuperior {
 			return i
 		}
 	}
-	// Se não encontrou, retorna a última faixa (maior alíquota)
 	return len(tabela) - 1
 }
 
@@ -77,27 +70,16 @@ func calcularImposto(baseCalculo float64, faixa domain.FaixaIRPF) float64 {
 }
 
 func (c *Calculator) CalcularIRPF(plr float64, tabela []domain.FaixaIRPF) (*domain.ResultadoIRPF, error) {
-	tabelaIRPF := domain.TabelaIRPF()
-
-	// Determinar a faixa de IRPF baseado no valor anual da PLR
-	faixaIndex := determinarFaixaIRPF(plr, tabelaIRPF)
-
-	if faixaIndex < 0 || faixaIndex >= len(tabelaIRPF) {
+	faixaIndex := determinarFaixaIRPF(plr, tabela)
+	if faixaIndex < 0 || faixaIndex >= len(tabela) {
 		return nil, fmt.Errorf("erro ao determinar a faixa de IRPF para o valor: R$ %.2f", plr)
 	}
-
-	faixa := tabelaIRPF[faixaIndex]
-
-	// Calcular o imposto
+	faixa := tabela[faixaIndex]
 	impostoApurado := calcularImposto(plr, faixa)
-
-	// Garantir que o imposto não seja negativo
 	if impostoApurado < 0 {
 		impostoApurado = 0
 	}
-
 	valorLiquido := plr - impostoApurado
-
 	logrus.WithFields(logrus.Fields{
 		"plrBruta":       plr,
 		"faixaIndex":     faixaIndex,
@@ -105,8 +87,7 @@ func (c *Calculator) CalcularIRPF(plr float64, tabela []domain.FaixaIRPF) (*doma
 		"parcelaDeduzir": faixa.ParcelaDeduzir,
 		"impostoApurado": impostoApurado,
 		"valorLiquido":   valorLiquido,
-	}).Debug("Cálculo de IRPF realizado")
-
+	}).Debug("Calculo de IRPF realizado")
 	return &domain.ResultadoIRPF{
 		Aliquota:       faixa.Aliquota,
 		ParcelaDeduzir: faixa.ParcelaDeduzir,

--- a/internal/finance/calculator_test.go
+++ b/internal/finance/calculator_test.go
@@ -16,7 +16,7 @@ func TestCalculator_CalcularPLR(t *testing.T) {
 	}{
 		{
 			name: "Caso padrão",
-			dados: domain.PLRDados;
+			 domain.PLRDados;
 				Salario:                 10000,
 				Multiplicador:           2,
 				PorcentagemParticipacao: 0.8,

--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ var salario float64
 var multiplicador float64
 var porcentagemParticipacao float64
 var mesesTrabalhados int
+var periodo string
 
 func main() {
 	var rootCmd = &cobra.Command{
@@ -25,11 +26,11 @@ func main() {
 		Run:   runPLRCalculator,
 	}
 
-	// Definindo as flags
 	rootCmd.Flags().Float64VarP(&salario, "salario", "s", 0.0, "Salário do funcionário")
 	rootCmd.Flags().Float64VarP(&multiplicador, "multiplicador", "m", 0.0, "Multiplicador da PLR")
 	rootCmd.Flags().Float64VarP(&porcentagemParticipacao, "participacao", "p", 0.0, "Porcentagem de participação nos lucros")
 	rootCmd.Flags().IntVarP(&mesesTrabalhados, "meses", "t", 0, "Número de meses trabalhados")
+	rootCmd.Flags().StringVar(&periodo, "periodo", "maio-mais", "Período da tabela IRPF: jan-abr ou maio-mais")
 
 	logrus.SetFormatter(&logrus.TextFormatter{})
 	logrus.SetOutput(os.Stdout)
@@ -41,19 +42,27 @@ func main() {
 }
 
 func runPLRCalculator(cmd *cobra.Command, args []string) {
-	// Verificar se as flags foram fornecidas
 	cmd.Flags().Parse(args)
 	salarioFlag, _ := cmd.Flags().GetFloat64("salario")
 	multiplicadorFlag, _ := cmd.Flags().GetFloat64("multiplicador")
 	porcentagemParticipacaoFlag, _ := cmd.Flags().GetFloat64("participacao")
 	mesesTrabalhadosFlag, _ := cmd.Flags().GetInt("meses")
+	periodoFlag, _ := cmd.Flags().GetString("periodo")
 
-	// Se nenhuma flag foi fornecida, usar o prompt interativo
 	if salarioFlag == 0 && multiplicadorFlag == 0 && porcentagemParticipacaoFlag == 0 && mesesTrabalhadosFlag == 0 {
 		salarioFlag = input.LeFloat64("Digite o salário: ")
 		multiplicadorFlag = input.LeFloat64("Digite o multiplicador da PLR: ")
 		porcentagemParticipacaoFlag = input.LeFloat64("Digite a porcentagem de participação nos lucros: ")
 		mesesTrabalhadosFlag = input.LeInt("Digite o número de meses trabalhados: ")
+		logrus.Info("Escolha o período da tabela IRPF:")
+		logrus.Info("1) Janeiro a Abril/2025")
+		logrus.Info("2) A partir de Maio/2025 (padrão)")
+		escolha := input.LeInt("Digite sua escolha (1 ou 2): ")
+		if escolha == 1 {
+			periodoFlag = "jan-abr"
+		} else {
+			periodoFlag = "maio-mais"
+		}
 	}
 
 	plrData := domain.PLRDados{
@@ -75,14 +84,20 @@ func runPLRCalculator(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	// Converter plrFormatada de volta para float
 	plrBruta, err := strconv.ParseFloat(strings.ReplaceAll(plrFormatada, ",", ""), 64)
 	if err != nil {
 		logrus.Errorf("Erro ao converter PLR formatada: %v", err)
 		return
 	}
 
-	tabelaIRPF := domain.TabelaIRPF()
+	var tabelaIRPF []domain.FaixaIRPF
+	if periodoFlag == "jan-abr" {
+		tabelaIRPF = domain.TabelaIRPFPLRJanAbr2025()
+		logrus.Info("Usando tabela IRPF: Janeiro a Abril/2025")
+	} else {
+		tabelaIRPF = domain.TabelaIRPFPLRAPartirDeMaio2025()
+		logrus.Info("Usando tabela IRPF: A partir de Maio/2025")
+	}
 
 	resultadoIRPF, err := calculadora.CalcularIRPF(plrBruta, tabelaIRPF)
 	if err != nil {


### PR DESCRIPTION
- Introduced separate tax tables for January-April 2025 and May+ 2025.
- Added a new `--periodo` flag to select the applicable IRPF table.
- Enhanced interactive CLI to allow period selection.
- Updated README with detailed instructions and examples of the new feature.